### PR TITLE
Update to naming scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 notes.txt
-py310
+py*


### PR DESCRIPTION
Updated to change `py310` to `py*` to account for any version naming scheme.